### PR TITLE
buildStartStepRq - setName variants

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,8 +4,8 @@ plugins {
 }
 apply plugin: 'java'
 apply from: 'release.gradle'
-sourceCompatibility = 1.6
-targetCompatibility = 1.6
+sourceCompatibility = 1.8
+targetCompatibility = 1.8
 
 description = 'TestNG Agent'
 

--- a/src/main/java/com/epam/reportportal/testng/TestNGService.java
+++ b/src/main/java/com/epam/reportportal/testng/TestNGService.java
@@ -45,10 +45,7 @@ import rp.com.google.common.base.Supplier;
 import javax.annotation.Nullable;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Method;
-import java.util.Calendar;
-import java.util.Collection;
-import java.util.Date;
-import java.util.List;
+import java.util.*;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import static rp.com.google.common.base.Strings.isNullOrEmpty;
@@ -283,9 +280,7 @@ public class TestNGService implements ITestNGService {
             return null;
         }
         StartTestItemRQ rq = new StartTestItemRQ();
-        String testStepName = testResult.getMethod().getMethodName();
-        rq.setName(testStepName);
-
+        rq.setName(Optional.ofNullable(testResult.getTestName()).orElse(testResult.getMethod().getMethodName()));
         rq.setDescription(createStepDescription(testResult));
         rq.setParameters(createStepParameters(testResult));
         rq.setUniqueId(extractUniqueID(testResult));


### PR DESCRIPTION
This is to get overridden getTestName() from "org.testng.ITest" in RP.

changed name will be at "testResult.getTestName()"
by default RP assign name like this "testResult.getMethod().getMethodName()"