### PR TITLE
now logger in BaseTestNgListener belongs to instance

### DIFF
--- a/src/main/java/com/epam/reportportal/testng/BaseTestNGListener.java
+++ b/src/main/java/com/epam/reportportal/testng/BaseTestNGListener.java
@@ -30,7 +30,7 @@ import java.util.concurrent.atomic.AtomicInteger;
  */
 public class BaseTestNGListener implements IExecutionListener, ISuiteListener, IResultListener2 {
 
-	private static final Logger LOGGER = LoggerFactory.getLogger(BaseTestNGListener.class);
+	private final Logger LOGGER = LoggerFactory.getLogger(BaseTestNGListener.class);
 
 	private static final AtomicInteger INSTANCES = new AtomicInteger(0);
 


### PR DESCRIPTION
fix for this issue
https://github.com/reportportal/logger-java-log4j/issues/8